### PR TITLE
Remove hyphen from slugify

### DIFF
--- a/assets/js/dist/base.js
+++ b/assets/js/dist/base.js
@@ -398,7 +398,7 @@ jQuery(document).ready(function ($) {
 	   console.log(e);
 	});
 
-
+  
 });
 
 jQuery(document).ready(function($) {

--- a/assets/js/dist/base.js
+++ b/assets/js/dist/base.js
@@ -329,7 +329,6 @@ function slugify() {
   output = output.toLowerCase();
   output = output.replace(/\s\s+/g, " ");
   output = output.trim();
-  output = output.replace(/\s/g, "-");
   return output;
 }
 
@@ -399,7 +398,7 @@ jQuery(document).ready(function ($) {
 	   console.log(e);
 	});
 
-  
+
 });
 
 jQuery(document).ready(function($) {

--- a/assets/js/old/new.js
+++ b/assets/js/old/new.js
@@ -6,7 +6,6 @@ jQuery(document).ready(function ($) {
     output = output.toLowerCase();
     output = output.replace(/\s\s+/g, " ");
     output = output.trim();
-    output = output.replace(/\s/g, "-");
     return output;
   }
   function encodeEntities(input) {

--- a/assets/js/src/blocks.js
+++ b/assets/js/src/blocks.js
@@ -329,7 +329,6 @@ function slugify() {
   output = output.toLowerCase();
   output = output.replace(/\s\s+/g, " ");
   output = output.trim();
-  output = output.replace(/\s/g, "-");
   return output;
 }
 


### PR DESCRIPTION
Now filenames will allow hyphens if they are in the title/headline of the page