### PR TITLE
Update tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to our repository.
 
 To set up:
 ```
-$ npm run dependencies
-$ npm run init
+$ npm run install
+$ npm run setup
 $ npm start
 ```

--- a/_data/content_types/communities.yml
+++ b/_data/content_types/communities.yml
@@ -60,9 +60,8 @@ blocks:
   name: Page Weight
   type: select-number
   options:
-    - blank
-    - 0
     - 1
+    - 0
   data_type: integer
   txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible"
   comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible"

--- a/_data/content_types/events.yml
+++ b/_data/content_types/events.yml
@@ -165,9 +165,8 @@ blocks:
   name: Page Weight
   type: select-number
   options:
-    - blank
-    - 0
     - 1
+    - 0
   data_type: integer
   txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible"
   comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible"

--- a/_data/content_types/news.yml
+++ b/_data/content_types/news.yml
@@ -83,9 +83,8 @@ blocks:
   name: Page Weight
   type: select-number
   options:
-    - blank
-    - 0
     - 1
+    - 0
   data_type: integer
   txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible"
   comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible"

--- a/_data/content_types/resources.yml
+++ b/_data/content_types/resources.yml
@@ -73,12 +73,11 @@ blocks:
   name: Page Weight
   type: select-number
   options:
-    - blank
-    - 0
     - 1
     - 2
+    - 0
   data_type: integer
-  txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible"
+  txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible<br/>2 -- highlighted"
   comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible\n# 2 -- highlighted"
 - id: aliases
   name: Redirects

--- a/_data/content_types/topics.yml
+++ b/_data/content_types/topics.yml
@@ -30,11 +30,10 @@ blocks:
   options:
     - 1
     - 2
-    - 3
     - 0
   data_type: integer
-  txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible"
-  comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible"
+  txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible<br/>2 -- featured on the Resource page"
+  comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible\n# 2 -- featured on the Resource page"
 - id: aliases
   name: Redirects
   type: textarea

--- a/_data/content_types/topics.yml
+++ b/_data/content_types/topics.yml
@@ -28,11 +28,10 @@ blocks:
   name: Page Weight
   type: select-number
   options:
-    - blank
-    - 0
     - 1
     - 2
     - 3
+    - 0
   data_type: integer
   txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible"
   comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ gulp.task('copy-uswds-images', () => {
 
 gulp.task('copy-uswds-js', () => {
   return gulp.src(`${uswds}/js/**/**`)
-  .pipe(gulp.dest(`${JS_DEST}`));
+  .pipe(gulp.dest(`${PROJECT_JS_DEST}`));
 });
 
 gulp.task('build-sass', function(done) {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A site for managing the digital.gov editorial workflow on GitHub",
   "main": "index.js",
   "scripts": {
-    "dependencies": "npm install && bundle install",
+    "install": "npm install && bundle install",
+    "setup": "npm run gulp -- init && git checkout -- ./assets/sass/_uswds-theme-typography.scss",
     "start": "bundle exec jekyll serve",
-    "gulp": "node ./node_modules/gulp/bin/gulp.js",
-    "init": "npm run gulp -- init && git checkout -- ./assets/sass/_uswds-theme-typography.scss"
+    "gulp": "node ./node_modules/gulp/bin/gulp.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dependencies": "npm install && bundle install",
-    "start": "bundler exec jekyll serve --incremental",
+    "start": "bundle exec jekyll serve",
     "gulp": "node ./node_modules/gulp/bin/gulp.js",
     "init": "npm run gulp -- init && git checkout -- ./assets/sass/_uswds-theme-typography.scss"
   },


### PR DESCRIPTION
Change:
- fix error in gulpfile.js when running `npm run init` where the variable had a typo:
```
ReferenceError: JS_DEST is not defined
```
- update `start` script in package.json to remove the `--incremental` flag as this was preventing the build of necessary files (data/community.yml in this example)
- Rename the npm scripts for clarity and consistency with related digital.gov repos
- Update the README.md to reflect the script updates

- Remove `0-blank` as a page weight option
- Set `1-visible` as the default page weight option
- Clarify the `topic` page weight options

Closes #28 