### PR TITLE
Add kicker to event page

### DIFF
--- a/_data/content_types/events.yml
+++ b/_data/content_types/events.yml
@@ -24,6 +24,11 @@ blocks:
   type: textarea
   data_type: string
   txt: "Think of this as the sentence you'd most like to tweet. Do not repeat the headline. You need to be able to read it outloud in a single breath."
+- id: kicker
+  name: Kicker
+  type: input
+  data_type: string
+  txt: "Highlight the relevant topic. This displays above the event title on the /events/ page. Should always be included. Use only one or two words."
 - id: summary
   name: Summary
   type: textarea


### PR DESCRIPTION
Add the `kicker` field to the `Event` content type.


The kicker is the short descriptive text displayed above the title. Ex. "DAP LEARNING SERIES, 10X, OR VIDEO (the default) once a youtube_id is added.

Closes #29 

<img width="861" alt="Screen Shot 2020-05-05 at 2 06 40 PM" src="https://user-images.githubusercontent.com/2197515/81100115-fbb1c380-8ed9-11ea-9299-7a06bb056a51.png">
