### PR TITLE
Update helper text for second community listing

### DIFF
--- a/_includes/form-builder.html
+++ b/_includes/form-builder.html
@@ -19,7 +19,7 @@
       {% for group in list %}
       <div class="margin-y-8 border-top-1px">
         <h3 class="margin-y-105"><i class="far fa-envelope"></i> Community list settings {% if i == 2 %}(additional){% endif %}</h3>
-        <p class="margin-0">Fill out these fields if the community has more than one listserv group. For example, the group has a federal-only list and an open to the public list. These settings control the "Join box" on the community page.</p>
+        <p class="margin-0">Fill out these fields if the community has more than one email group. For example, the group has a federal-only list and an open to the public list. These settings control the "Join box" on the community page.</p>
         {% for sub_blocks in group %}
           {% for sub_block in sub_blocks %}
             {% if sub_block.type %}

--- a/_includes/form-builder.html
+++ b/_includes/form-builder.html
@@ -18,8 +18,8 @@
     {% for list in block.lists %}
       {% for group in list %}
       <div class="margin-y-8 border-top-1px">
-        <h3 class="margin-y-105"><i class="far fa-envelope"></i> Community list settings {% if i == 2 %}(second){% endif %}</h3>
-        <p class="margin-0">These settings control the "Join box" on the community page.</p>
+        <h3 class="margin-y-105"><i class="far fa-envelope"></i> Community list settings {% if i == 2 %}(additional){% endif %}</h3>
+        <p class="margin-0">Fill out these fields if the community has more than one listserv group. For example, the group has a federal-only list and an open to the public list. These settings control the "Join box" on the community page.</p>
         {% for sub_blocks in group %}
           {% for sub_block in sub_blocks %}
             {% if sub_block.type %}


### PR DESCRIPTION
For communities  pages: 

- Update the helper text to make it more clear that the second list box isn't required

**_Before:_**
<img width="677" alt="Screen Shot 2020-05-05 at 2 15 58 PM" src="https://user-images.githubusercontent.com/2197515/81100903-4c75ec00-8edb-11ea-8399-e9fe76796789.png">

**_After:_**
<img width="636" alt="Screen Shot 2020-05-05 at 2 15 39 PM" src="https://user-images.githubusercontent.com/2197515/81100906-4c75ec00-8edb-11ea-9579-fa3b7d4519f4.png">


Closes #30 