### PR TITLE
Default weight to zero

### DIFF
--- a/_data/content_types/events.yml
+++ b/_data/content_types/events.yml
@@ -170,8 +170,8 @@ blocks:
   name: Page Weight
   type: select-number
   options:
-    - 1
     - 0
+    - 1
   data_type: integer
   txt: "Controls how this page appears across the site<br/>0 -- hidden<br/>1 -- visible"
   comment: "Page weight: controls how this page appears across the site\n# 0 -- hidden\n# 1 -- visible"


### PR DESCRIPTION
Defaults the weight to zero.

“Bug” (?) on Event pages occurs when Page Weight is in front matter (is auto added in Workflow https://workflow.digital.gov/new/events/): the event will appear at the end of the upcoming list instead of correct chrono order. 